### PR TITLE
Restrict access to user views until they are registered/logged in.

### DIFF
--- a/car-reviews/src/App.js
+++ b/car-reviews/src/App.js
@@ -3,11 +3,23 @@ import './App.css';
 import MainPage from './components/MainPage/MainPage';
 import UserPage from './components/UserPage/UserPage';
 import MyReviews from './components/UserPage/myreviews';
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 import BillingContainer from './components/UserPage/billingcontainer';
 import Settings from './components/UserPage/settings';
 import SearchResults from './components/MainPage/searchresults';
 import Login from './components/MainPage/loginRegister';
+import AuthService from './components/Auth/AuthService';
+
+const Auth = new AuthService();
+
+const PrivateRoute = ({ component: Component, ...rest }) => (
+  <Route
+    {...rest}
+    render={props =>
+      Auth.loggedIn() === true ? <Component {...props} /> : <Redirect to="/login" />
+    }
+  />
+);
 
 class App extends Component {
   render() {
@@ -16,11 +28,11 @@ class App extends Component {
         <Switch>
           <Route exact path="/" component={MainPage} />
           <Route path="/searchpage" component={SearchResults} />
-          <Route path="/UserPage" component={UserPage} />
-          <Route path="/Billing" component={BillingContainer} />
+          <PrivateRoute path="/UserPage" component={UserPage} />
+          <PrivateRoute path="/Billing" component={BillingContainer} />
           {/* I removed /UserPage before /MyReviews because something is bugged in UserPage in this build */}
-          <Route path="/MyReviews" component={MyReviews} />
-          <Route path="/Settings" component={Settings} />
+          <PrivateRoute path="/MyReviews" component={MyReviews} />
+          <PrivateRoute path="/Settings" component={Settings} />
           <Route path="/Login" component={Login} />
         </Switch>
       </div>


### PR DESCRIPTION
# Description

Restrict access to user views until they are registered/logged in. (Protected Routes)
- These include Billing, My Reviews, and Settings.
- If trying to access these pages w/o logging in, redirects to '/login'


Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Testing it on my localhost. Trying to navigate to various parts of the application while being logged in and while being logged out.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
